### PR TITLE
Force AMDGPU to ignore PCIe atomic ops requirement

### DIFF
--- a/amd/amdgpu/amdgpu_device.c
+++ b/amd/amdgpu/amdgpu_device.c
@@ -4063,28 +4063,17 @@ int amdgpu_device_init(struct amdgpu_device *adev,
 			return r;
 	}
 
-	/* enable PCIE atomic ops */
-	if (amdgpu_sriov_vf(adev)) {
-		if (adev->virt.fw_reserve.p_pf2vf)
-			adev->have_atomics_support = ((struct amd_sriov_msg_pf2vf_info *)
-						      adev->virt.fw_reserve.p_pf2vf)->pcie_atomic_ops_support_flags ==
-				(PCI_EXP_DEVCAP2_ATOMIC_COMP32 | PCI_EXP_DEVCAP2_ATOMIC_COMP64);
-	/* APUs w/ gfx9 onwards doesn't reply on PCIe atomics, rather it is a
-	 * internal path natively support atomics, set have_atomics_support to true.
-	 */
-	} else if ((adev->flags & AMD_IS_APU) &&
-		   (amdgpu_ip_version(adev, GC_HWIP, 0) >
-		    IP_VERSION(9, 0, 0))) {
-		adev->have_atomics_support = true;
-	} else {
-		adev->have_atomics_support =
-			!pci_enable_atomic_ops_to_root(adev->pdev,
-					  PCI_EXP_DEVCAP2_ATOMIC_COMP32 |
-					  PCI_EXP_DEVCAP2_ATOMIC_COMP64);
-	}
-
-	if (!adev->have_atomics_support)
-		dev_info(adev->dev, "PCIE atomic ops is not supported\n");
+       /* enable PCIE atomic ops */
+       adev->have_atomics_support = true;
+       if (amdgpu_sriov_vf(adev)) {
+               /* VFs rely on PF-managed configuration; nothing further to do. */
+       } else if (!((adev->flags & AMD_IS_APU) &&
+                    (amdgpu_ip_version(adev, GC_HWIP, 0) >
+                     IP_VERSION(9, 0, 0)))) {
+               (void)pci_enable_atomic_ops_to_root(adev->pdev,
+                                                    PCI_EXP_DEVCAP2_ATOMIC_COMP32 |
+                                                    PCI_EXP_DEVCAP2_ATOMIC_COMP64);
+       }
 
 	/* doorbell bar mapping and doorbell index init*/
 	amdgpu_doorbell_init(adev);


### PR DESCRIPTION
## Summary
- force `have_atomics_support` to true so PCIe atomic failures never gate init
- retain atomic enable attempts without enforcing support or logging warnings

## Testing
- `make -C /lib/modules/6.8.0-53-generic/build M=$(pwd)/amd/amdgpu amdgpu_device.o -j5`


------
https://chatgpt.com/codex/tasks/task_e_68d156c986fc83308649e3928f979ffd